### PR TITLE
security: add least-privilege workflow permissions

### DIFF
--- a/.github/workflows/_compile_integration_test.yml
+++ b/.github/workflows/_compile_integration_test.yml
@@ -8,6 +8,9 @@ on:
         type: string
         description: "From which folder this pipeline executes"
 
+permissions:
+  contents: read
+
 env:
   POETRY_VERSION: "1.8.2"
 

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -8,6 +8,9 @@ on:
         type: string
         description: "From which folder this pipeline executes"
 
+permissions:
+  contents: read
+
 env:
   POETRY_VERSION: "1.8.2"
   WORKDIR: ${{ inputs.working-directory == '' && '.' || inputs.working-directory }}

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -15,6 +15,9 @@ on:
         default: 'libs/ai21'
         description: "From which folder this pipeline executes"
 
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: "3.11"
   POETRY_VERSION: "1.8.2"
@@ -73,7 +76,9 @@ jobs:
       - build
     uses:
       ./.github/workflows/_test_release.yml
-    permissions: write-all
+    permissions:
+      id-token: write
+      contents: read
     with:
       working-directory: ${{ inputs.working-directory }}
     secrets: inherit

--- a/.github/workflows/_scheduled_test.yml
+++ b/.github/workflows/_scheduled_test.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron:  '0 13 * * *'
 
+permissions:
+  contents: read
+
 env:
   POETRY_VERSION: "1.8.2"
 

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -8,6 +8,9 @@ on:
         type: string
         description: "From which folder this pipeline executes"
 
+permissions:
+  contents: read
+
 env:
   POETRY_VERSION: "1.8.2"
 

--- a/.github/workflows/_test_release.yml
+++ b/.github/workflows/_test_release.yml
@@ -8,6 +8,9 @@ on:
         type: string
         description: "From which folder this pipeline executes"
 
+permissions:
+  contents: read
+
 env:
   POETRY_VERSION: "1.8.2"
   PYTHON_VERSION: "3.10"

--- a/.github/workflows/check_diffs.yml
+++ b/.github/workflows/check_diffs.yml
@@ -12,6 +12,9 @@ on:
 # There's no point in testing an outdated version of the code. GitHub only allows
 # a limited number of job runners to be active at the same time, so it's better to cancel
 # pointless jobs early so that more useful jobs can run sooner.
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary
- Add explicit `permissions` blocks to all 7 workflow files that were missing them (only `_codespell.yml` already had one)
- All read-only workflows (`_lint`, `_test`, `_compile_integration_test`, `_scheduled_test`, `check_diffs`) get `permissions: contents: read`
- `_release.yml` gets top-level `permissions: contents: read`, and the `test-pypi-publish` job is narrowed from `write-all` to `id-token: write` + `contents: read` (jobs that need more — `publish` and `mark-release` — already had correct job-level overrides)
- `_test_release.yml` gets top-level `permissions: contents: read` (the `publish` job already overrides with `id-token: write`)

## Why
Without explicit permissions, workflows inherit the repository's default token permissions, which is typically `write` across all scopes. This is unnecessarily broad and increases blast radius if a dependency or action is compromised.

## Test plan
- [ ] Verify CI passes on this PR (lint, test, compile-integration-tests all use `contents: read`)
- [ ] Spot-check that release workflow still works on next release (the `id-token: write` + `contents: read` combo is what PyPI trusted publishing needs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)