### PR TITLE
fix: use invocation model in trace params

### DIFF
--- a/libs/ai21/langchain_ai21/chat_models.py
+++ b/libs/ai21/langchain_ai21/chat_models.py
@@ -113,7 +113,7 @@ class ChatAI21(BaseChatModel, AI21Base):
         params = self._get_invocation_params(stop=stop, **kwargs)
         ls_params = LangSmithParams(
             ls_provider="ai21",
-            ls_model_name=self.model,
+            ls_model_name=params.get("model", self.model),
             ls_model_type="chat",
             ls_temperature=params.get("temperature", self.temperature),
         )


### PR DESCRIPTION
now reads `ls_model_name` from the resolved invocation params (falling back to `self.model`) instead of always using the instance default.